### PR TITLE
Don't send healthcheck output to a file called '1'.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,4 @@ RUN (\
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/sbin/entrypoint.sh"]
 CMD ["echo", "Usage: COMMAND [ARG...]\nExample: guestfish --version"]
 
-HEALTHCHECK --interval=5s --timeout=5s --start-period=20s CMD pgrep qemu &>1 || exit 1
+HEALTHCHECK --interval=5s --timeout=5s --start-period=20s CMD pgrep qemu 2>&1 || exit 1


### PR DESCRIPTION
Previously, the stdout and stderr of 'pgrep qemu' would be sent to a file called '1'. Instead, just send them both to stdout so that docker can log it.